### PR TITLE
Simpler api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Parse JSON and download image data
 
-Simple script to parse JSON from URL and download jpg images (on any JSON leaf nodes).
+Simple script to parse JSON from URL and download jpg/jpeg/png images (on any JSON leaf nodes).
 
-Also generates a json file that maps url to the generated image names
+Also generates a json file that maps url to the generated image names.
 
 ## Install
 ```
@@ -16,19 +16,13 @@ npm start -- --help
 
 ## Run
 ```
-// get images from url
 npm start -- --url <url>
 //e.g.
 npm start -- --url https://my-site.com/json-endpoint
-
-// optional arguments for output image directory and map name
-npm start -- url <url> --output <output file directory name> --map <map json file name>
-// e.g.
-npm start -- --url https://my-site.com/json-endpoint --output myimages --map mymap.json
 ```
-If no optional arguments given,
-- Default output images directory: ./output
-- Default map json file: ./map.json
+## Output
+- images directory: ./generated/output
+- map json file: ./generated/map.json
 
 ## Map Json File
 map json file will be of the format  - url : filename, e.g.:

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ npm start -- --help
 ## Run
 ```
 npm start -- --url <url>
-//e.g.
+// e.g.
 npm start -- --url https://my-site.com/json-endpoint
+
+// with optional arguments
+// e.g.
+npm start -- --url https://my-site.com/json-endpoint --output my_images --map my_map.json
 ```
 ## Output
 - images directory: ./generated/output
 - map json file: ./generated/map.json
+
+If optional output or map argument provided, custom directory/file names under ./generated will be used instead.
 
 ## Map Json File
 map json file will be of the format  - url : filename, e.g.:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse JSON and download image data
 
-Simple script to parse JSON from URL and download jpg/jpeg/png images (on any JSON leaf nodes).
+Simple script to parse JSON from URL and download jpg/jpeg/png/gif images (on any JSON leaf nodes).
 
 Also generates a json file that maps url to the generated image names.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple script to parse JSON from URL and download jpg images (on any JSON leaf nodes).
 
-Allows for caching downloaded images to prevent duplicate downloads.
+Also generates a json file that maps url to the generated image names
 
 ## Install
 ```
@@ -16,19 +16,27 @@ npm start -- --help
 
 ## Run
 ```
-npm start -- --url <url> --output <output file directory> --cache <cache json file>
+// get images from url
+npm start -- --url <url>
+//e.g.
+npm start -- --url https://my-site.com/json-endpoint
 
+// optional arguments for output image directory and map name
+npm start -- url <url> --output <output file directory name> --map <map json file name>
 // e.g.
-npm start -- --url https://my-site.com/json-endpoint --output ./assets/images --cache ./src/cache.json
+npm start -- --url https://my-site.com/json-endpoint --output myimages --map mymap.json
 ```
+If no optional arguments given,
+- Default output images directory: ./output
+- Default map json file: ./map.json
 
-## Cache Json File
-cache json file should be of the format  - url : filepath, e.g.:
+## Map Json File
+map json file will be of the format  - url : filename, e.g.:
 ```
-// cache.json
+// map.json
 {
-    'https://my-site.com/image1.jpg' : './assets/images/image1.jpg',
-    'https://my-site.com/image2.jpg' : './assets/images/image2.jpg'
+    'https://my-site.com/image1.jpg' : 'image1.jpg',
+    'https://my-site.com/image2.jpg' : 'image2.jpg'
 }
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,7 @@ import path from 'path';
 
 program.version('0.1.0');
 
-program
-    .requiredOption('--url <url>', 'json url')
-    .option('--output <output>', 'image output directory filepath')
-    .option('--map <cache>', 'json file that maps image url to image filename')
+program.requiredOption('--url <url>', 'json url')
 
 interface JsonObject {
     [key: string]: JsonObject | string
@@ -60,8 +57,8 @@ const main = async () => {
     // get user input
     program.parse(process.argv)
     const url = program.url
-    const imageOutputDirFilepath = program.output || 'images'
-    const mapFilePath = program.cache || 'map.json'
+    const imageOutputDirFilepath =  './generated/images'
+    const mapFilePath =  './generated/map.json'
 
     // remove file if exist
     if (fs.existsSync(mapFilePath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,15 @@ const fetchJsonFromUrl = async (url: string): Promise<JsonObject> => {
 // random string identifier
 const getRandomString = () => Math.random().toString(36).substr(2, 9)
 
-// given a json object and result array, collect all jpg/jpeg/png image url in result array
+// given a json object and result array, collect all jpg/jpeg/png/gif image url in result array
 const collectImageUrls = (jsonObject: JsonObject | string, resultArray: string[]) => {
     if (typeof jsonObject === 'string') {
         if (jsonObject.startsWith('https://') &&
-            (jsonObject.endsWith('.jpg') || jsonObject.endsWith('.jpeg') || jsonObject.endsWith('.png'))) {
+            (jsonObject.endsWith('.jpg') ||
+                jsonObject.endsWith('.jpeg') ||
+                jsonObject.endsWith('.png') ||
+                jsonObject.endsWith('.gif'))
+        ) {
             resultArray.push(jsonObject)
         }
     } else { // recursively traverse
@@ -95,11 +99,12 @@ const main = async () => {
     await Promise.all(resultUrls.map(async url => {
         if (!cacheJsonObject[url]) { // if not downloaded
             // generate random string
-            const outputImageFilePath = path.join(imageOutputDirFilepath, getRandomString() + '.jpg')
+            const outputImageFileName = getRandomString() + '.jpg'
+            const outputImageFilePath = path.join(imageOutputDirFilepath, outputImageFileName)
             const urlImage = await fetch(url)
             const outputImage = fs.createWriteStream(outputImageFilePath)
             urlImage.body.pipe(outputImage) // write image
-            cacheJsonObject[url] = outputImageFilePath // add to cache
+            cacheJsonObject[url] = outputImageFileName// add to cache
         }
     }))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import path from 'path';
 
 program.version('0.1.0');
 
-program.requiredOption('--url <url>', 'json url')
+program
+    .requiredOption('--url <url>', 'json url')
+    .option('--output <output>', 'directory name for output images')
+    .option('--map <map>', 'file name for map json file')
 
 interface JsonObject {
     [key: string]: JsonObject | string
@@ -22,8 +25,8 @@ const getRandomString = () => Math.random().toString(36).substr(2, 9)
 // given a json object and result array, collect all jpg/jpeg/png image url in result array
 const collectImageUrls = (jsonObject: JsonObject | string, resultArray: string[]) => {
     if (typeof jsonObject === 'string') {
-        if (jsonObject.startsWith('https://') && 
-        (jsonObject.endsWith('.jpg') || jsonObject.endsWith('.jpeg') || jsonObject.endsWith('.png'))) {
+        if (jsonObject.startsWith('https://') &&
+            (jsonObject.endsWith('.jpg') || jsonObject.endsWith('.jpeg') || jsonObject.endsWith('.png'))) {
             resultArray.push(jsonObject)
         }
     } else { // recursively traverse
@@ -56,9 +59,12 @@ const removeFilesInDirectory = (dirPath: string) => {
 const main = async () => {
     // get user input
     program.parse(process.argv)
+    const generatedDir = './generated'
     const url = program.url
-    const imageOutputDirFilepath =  './generated/images'
-    const mapFilePath =  './generated/map.json'
+    const imageOutputDirFilepath = program.output ?
+        path.join(generatedDir, program.output) : path.join(generatedDir, 'images')
+    const mapFilePath = program.map ?
+        path.join(generatedDir, program.map) : path.join(generatedDir, 'map.json')
 
     // remove file if exist
     if (fs.existsSync(mapFilePath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,11 @@ const fetchJsonFromUrl = async (url: string): Promise<JsonObject> => {
 // random string identifier
 const getRandomString = () => Math.random().toString(36).substr(2, 9)
 
-// given a json object and result array, collect all jpg image url in result array
+// given a json object and result array, collect all jpg/jpeg/png image url in result array
 const collectImageUrls = (jsonObject: JsonObject | string, resultArray: string[]) => {
     if (typeof jsonObject === 'string') {
-        if (jsonObject.startsWith('https://') && jsonObject.endsWith('.jpg')) {
+        if (jsonObject.startsWith('https://') && 
+        (jsonObject.endsWith('.jpg') || jsonObject.endsWith('.jpeg') || jsonObject.endsWith('.png'))) {
             resultArray.push(jsonObject)
         }
     } else { // recursively traverse


### PR DESCRIPTION
The idea is just to output and images folder with the downloaded images, and a json map file that contains mapping from url to image filename (previously was mapping url to image filepath, which can be difficult to use)

- instead for checking existing map / cache, script will remove existing images folder and existing map/cache file and redo the process
- provide default filepaths for output directory and json map file, under ./generated
- update Readme